### PR TITLE
Add an option "no-minify" to prevent minify docs generated

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,9 @@ module.exports = function (options) {
     if (opts.verbose) {
       args.push('--verbose', opts.verbose);
     }
+    if (opts['no-minify']) {
+      args.push('--no-minify');
+    }
     args.push(firstFile.base);
 
     exec(bin + args.join(' '), function (error, stdout, stderr) {


### PR DESCRIPTION
Styledocco has [an option "minify"](https://github.com/jacobrask/styledocco/blob/master/bin/styledocco#L40) to minify docs and the option is true by the default.
But we can prevent the behavior to make human-readable docs by using `--no-minify`.
This patch provides the minification-control.
